### PR TITLE
Add dynamic queues to setup function in `ChannelWrapper`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,9 @@ name: Publish NPM package
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   CLOUDAMQP_API_KEY: ${{ secrets.CLOUDAMQP_API_KEY }}
@@ -21,5 +22,6 @@ jobs:
       - run: npm run build
       - run: npm test
       - uses: JS-DevTools/npm-publish@v1
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           token: ${{ env.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-message-bus",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-message-bus",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "@types/amqplib": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-message-bus",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "Minimalistic and complete AMQP message bus implementation",
   "main": "lib/index.js",
   "files": [

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -118,9 +118,7 @@ export async function consumeMessages<Message extends IMessage>(
   queueName: ConsumeMessagesConfig | string,
   handler: MessageHandler<Message>
 ) {
-  console.log('📍 consumeMessages', queueName);
   let prefetch: number | undefined;
-  const channel = await getDefaultChannel();
   if (typeof queueName !== 'string') {
     if (!queueName.queues || queueName.queues.length !== 1) {
       throw new Error(
@@ -135,6 +133,7 @@ export async function consumeMessages<Message extends IMessage>(
     }
   }
 
+  const channel = await getDefaultChannel();
   const queue = getMessageBusConfig().queues.find((q) => q.name === queueName);
   const consumerTag = `${
     process.env.HOSTNAME || 'no.env.HOSTNAME'

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -13,7 +13,7 @@ import {
   pushToLastRejectedMessages,
 } from 'Utils';
 import { ChannelWrapper } from 'amqp-connection-manager';
-import { ConfirmChannel, ConsumeMessage } from 'amqplib';
+import { ConsumeMessage } from 'amqplib';
 import { DEFAULT_EXCHANGE_NAME } from './Const';
 import { getDefaultChannel } from './channel';
 import { configureMessageBus, getMessageBusConfig } from './config';
@@ -118,6 +118,7 @@ export async function consumeMessages<Message extends IMessage>(
   queueName: ConsumeMessagesConfig | string,
   handler: MessageHandler<Message>
 ) {
+  console.log('📍 consumeMessages', queueName);
   let prefetch: number | undefined;
   const channel = await getDefaultChannel();
   if (typeof queueName !== 'string') {
@@ -132,9 +133,6 @@ export async function consumeMessages<Message extends IMessage>(
     if (prefetchCount) {
       prefetch = prefetchCount;
     }
-    channel.addSetup(async (channel: ConfirmChannel) => {
-      await configureMessageBus(config, channel);
-    });
   }
 
   const queue = getMessageBusConfig().queues.find((q) => q.name === queueName);


### PR DESCRIPTION
Add queues created via `consumeMessage` call to setup function which will recreate these queues on reconnection to message broker. 

According to docs: https://github.com/jwalton/node-amqp-connection-manager
<img width="882" alt="image" src="https://github.com/nikitaeverywhere/node-message-bus/assets/95881717/5ea07cbc-1887-4a79-b21d-e01dd4751d21">
